### PR TITLE
Fixed HTTPServer import problem for Python2

### DIFF
--- a/jsonrpcserver/http_server.py
+++ b/jsonrpcserver/http_server.py
@@ -6,7 +6,7 @@ https://docs.python.org/3/library/http.server.html
 import logging
 try:
     # Python 2
-    import SimpleHTTPServer as HTTPServer
+    from BaseHTTPServer import HTTPServer
     from BaseHTTPServer import BaseHTTPRequestHandler
 except ImportError:
     # Python 3


### PR DESCRIPTION
While calling methods.serve_forever() (using Python 2.7.12), I was receiving the error "TypeError: 'module' object is not callable". This issue can be replicated by running the built-in example on the [examples page](https://jsonrpcserver.readthedocs.io/en/latest/examples.html#plain-jsonrpcserver).

```python
>>> from jsonrpcserver import Methods
>>> methods = Methods()
>>> @methods.add
... def ping():
...     return "pong"
... 
>>> methods.serve_forever()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/jsonrpcserver/http_server.py", line 42, in serve_forever
    httpd = HTTPServer((name, port), RequestHandler)
```

 This is because jsonrpcserver.http_server is importing HTTPServer from SimpleHTTPServer which results in HTTPServer being a module rather than a class. This now imports from BaseHTTPServer. Running the example again with this change results in the http server running as expected.

```python
>>> from jsonrpcserver import Methods
>>> methods = Methods()
>>> @methods.add
... def ping():
...     return "pong"
... 
>>> methods.serve_forever()
 * Listening on port 5000
```
