### PR TITLE
Now `convert_camel_case` works fine with array params + tests

### DIFF
--- a/jsonrpcserver/request.py
+++ b/jsonrpcserver/request.py
@@ -186,7 +186,8 @@ class Request(object):
             # Convert camelCase to underscore
             if config.convert_camel_case:
                 self.method_name = _convert_camel_case(self.method_name)
-                self.kwargs = _convert_camel_case_keys(self.kwargs)
+                if self.kwargs:
+                    self.kwargs = _convert_camel_case_keys(self.kwargs)
             self.response = None
 
     def call(self, methods):

--- a/test/unit/test_request.py
+++ b/test/unit/test_request.py
@@ -242,6 +242,11 @@ class TestRequestInit(TestCase):
         self.assertEqual('foo_method', req.method_name)
         self.assertEqual({'foo_param': 1, 'a_dict': {'bar_param': 1}}, req.kwargs)
 
+    def test_positional_args_convert_case_skip(self):
+        config.convert_camel_case = True
+        req = Request({'jsonrpc': '2.0', 'method': 'foo', 'params': ['Camel', 'Case']})
+        self.assertEqual(['Camel', 'Case'], req.args)
+
 
 class TestRequestIsNotification(TestCase):
 


### PR DESCRIPTION
Broken when `jsonrpcserver.config.convert_camel_case` set to `True` and pass method params like an array.

This PR fix this