### PR TITLE
Refactor for Request subclassing

### DIFF
--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -9,8 +9,8 @@ from .response import BatchResponse, NotificationResponse
 
 class AsyncRequests(Requests):
     """Asynchronous requests."""
-    def __init__(self, requests):
-        super(AsyncRequests, self).__init__(requests, request_type=AsyncRequest)
+    def __init__(self, requests, request_type=AsyncRequest):
+        super(AsyncRequests, self).__init__(requests, request_type=request_type)
 
     async def dispatch(self, methods, context=None):
         """

--- a/jsonrpcserver/async_request.py
+++ b/jsonrpcserver/async_request.py
@@ -14,7 +14,7 @@ class AsyncRequest(Request):
             # Handles setting the result/exception of the call
             with self.handle_exceptions():
                 # Get the method object from a list (raises MethodNotFound)
-                callable_ = get_method(methods, self.method_name)
+                callable_ = self._get_method(methods)
                 # Ensure the arguments match the method's signature
                 validate_arguments_against_signature(callable_, self.args, self.kwargs)
                 # Call the method

--- a/jsonrpcserver/request.py
+++ b/jsonrpcserver/request.py
@@ -87,7 +87,7 @@ class Request(object):
             # Handle setting the result/exception of the call
             with self.handle_exceptions():
                 # Get the method object from a list (raises MethodNotFound)
-                callable_ = get_method(methods, self.method_name)
+                callable_ = self._get_method(methods)
                 # Ensure the arguments match the method's signature
                 validate_arguments_against_signature(callable_, self.args, self.kwargs)
                 # Call the method
@@ -100,3 +100,13 @@ class Request(object):
         # Ensure the response has been set before returning it
         assert isinstance(self.response, Response), 'Invalid response type'
         return self.response
+
+    def _get_method(self, methods):
+        """
+        Find and return a callable representing the method for this request.
+
+        :param methods: List or dictionary of named functions
+        :raises MethodNotFound: If no method is found
+        :returns: Callable representing the method
+        """
+        return get_method(methods, self.method_name)


### PR DESCRIPTION
- expose request_type param on Requests to AsyncRequests.__init__()
- refactor method lookup on Request to allow overriding in subclasses

These changes allow for easier use of Request subclasses for special behavior. In our specific case, we want to register a class instead of a method, instantiate the class with some run-time info, and then call a method on the class to handle the request. This is doable with the current implementation, but it requires lots of copy/paste on the subclasses. These small changes would significantly simplify the implementation and could be used for other custom method lookup behavior as well.

