### PR TITLE
allow request_id to be falsy but not None, fix #56

### DIFF
--- a/jsonrpcserver/response.py
+++ b/jsonrpcserver/response.py
@@ -77,7 +77,7 @@ class RequestResponse(Response, dict):
             returned.
         """
         # Ensure we're not responding to a notification with data
-        if not request_id:
+        if request_id is None:
             raise ValueError(
                 'Requests must have an id, use NotificationResponse instead')
         super(RequestResponse, self).__init__(


### PR DESCRIPTION
Addresses https://github.com/bcb/jsonrpcserver/issues/56