### PR TITLE
Pass context even when no parameters available

### DIFF
--- a/jsonrpcserver/request.py
+++ b/jsonrpcserver/request.py
@@ -102,11 +102,7 @@ class Request:
         """
         self.jsonrpc = jsonrpc
         self.method = method
-        self.args, self.kwargs = (
-            get_arguments(params, context=context)
-            if isinstance(params, (list, dict))
-            else ([], {})
-        )
+        self.args, self.kwargs = get_arguments(params or NOPARAMS, context=context)
         self.id = id
 
         if convert_camel_case:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -57,6 +57,12 @@ def test_get_arguments_keyword_with_context():
     assert args == (["baz"], {"foo": "bar"})
 
 
+# With the "context" argument, but without params
+def test_get_arguments_no_params_with_context():
+    args = get_arguments(context="bar")
+    assert args == (["bar"], {})
+
+
 def test_request():
     assert Request(method="foo").method == "foo"
 


### PR DESCRIPTION
I have some endpoints which need a context parameter even when they take no other jsonrpc params.

In my special case I am passing a django request in order to perform granular authentication of each jsonrpc endpoint: some endpoints require the user to be logged in, some do not. For that, I pass the django request as context parameter.

For the jsonrpc endpoints without params, this was failing. With this patch, the context is passed even if no params are provided.