### PR TITLE
Replace the funcsigs backport with inspect from the standard library

### DIFF
--- a/jsonrpcserver/methods.py
+++ b/jsonrpcserver/methods.py
@@ -8,7 +8,7 @@ limitation of JSON-RPC).
 """
 from typing import Any, Callable, Optional
 
-from funcsigs import signature  # type: ignore
+from inspect import signature
 
 Method = Callable[..., Any]
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=["apply_defaults<1", "jsonschema>=2,<4", "funcsigs>=1,<2"],
+    install_requires=["apply_defaults<1", "jsonschema>=2,<4"],
     license="MIT",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
funcsigs is a backport of PEP 362 function signature for Python < 3.3.
Since jsonrpcserver currently supports Python >= 3.6, the backport is no
longer necessary.