### PR TITLE
Add Methods factory from objects

### DIFF
--- a/jsonrpcserver/methods.py
+++ b/jsonrpcserver/methods.py
@@ -8,7 +8,7 @@ limitation of JSON-RPC).
 """
 from typing import Any, Callable, Optional
 
-from inspect import signature
+from inspect import signature, getmembers
 
 Method = Callable[..., Any]
 
@@ -38,6 +38,29 @@ def validate(method: Callable) -> Callable:
 
 class Methods:
     """Holds a list of methods that can be called by a JSON-RPC request."""
+
+    @classmethod
+    def from_object(cls, obj: Any) -> "Methods":
+        """
+        Create a Methods with all public callable attributes of an object.
+
+        Public attributes are attributes that do not start with an underscore.
+
+        N.B. When passing this a class, instance methods will be included with
+        their first argument as a "self" instance.
+
+        Args:
+            obj: Object whose public methods will be part of the returned Methods.
+
+        Returns:
+            Methods containing only the public methods of the given object.
+        """
+        methods = {
+            attr_name: attr
+            for attr_name, attr in getmembers(obj)
+            if not attr_name.startswith("_") and callable(attr)
+        }
+        return cls(**methods)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.items = {}  # type: dict

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -126,6 +126,55 @@ def test_add_instance_method_custom_name():
     assert methods.items["custom2"].__call__() == "b"
 
 
+def test_methods_from_class():
+    class FooClass:
+        @staticmethod
+        def staticmethod():
+            return "Static"
+
+        @classmethod
+        def classmethod():
+            return "Static"
+
+        def public(self):
+            return "Public"
+
+        def _private(self):
+            return "Private"
+
+    methods = Methods.from_object(FooClass)
+
+    assert "staticmethod" in methods.items
+    assert "classmethod" in methods.items
+    assert "public" in methods.items
+    assert "_private" not in methods.items
+
+    # We must have instance for instance methods
+    with pytest.raises(Exception):
+        methods.items["public"]()
+
+
+def test_methods_from_instance():
+    class FooClass:
+        def __init__(self, name):
+            self.name = name
+
+        def get_name(self):
+            return self.name
+
+        def set_name(self, name):
+            self.name = name
+
+    obj = FooClass("A")
+    methods = Methods.from_object(obj)
+
+    # You cannot access the underlying function (i.e. 'is') without dot syntax.
+    assert methods.items["get_name"] == obj.get_name
+    # obj and methods must be linked
+    methods.items["set_name"]("B")
+    assert obj.get_name() == "B"
+
+
 def test_add_function_via_decorator():
     methods = Methods()
 


### PR DESCRIPTION
I added a new classmethod `jsonrpcserver.methods.Methods.from_object` that takes an object and returns a `Methods` with all public callable attributes (i.e. those that don't start with underscore) in that object.

While integrating jsonrpcserver into some legacy code for one of my clubs, I ran into the issue where we have an ABC that multiple classes inherit. I wanted to maintain this hierarchy and I didn't like listing out all the attributes to add to the `Methods` for `dispatch`, since there are a lot. So I created this!

I considered adding a `expose` and `hide` decorator that could be optionally used as an alternative to the underscore method. I still can add it if you want, but I figured it wasn't necessary in most contexts.