### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     name="jsonrpcserver",
-    package_data={"jsonrpcserver": ["request-schema.json"]},
+    package_data={"jsonrpcserver": ["request-schema.json", "py.typed"]},
     packages=["jsonrpcserver"],
     url="https://github.com/bcb/jsonrpcserver",
     version="4.0.5",


### PR DESCRIPTION
Closes #91 

I tested this fork in my project, which uses types provided by this project, and it works. I no longer get "Cannot find module named 'jsonrpcserver'" and everything type checks successfully.