### PR TITLE
Avoid interpreting `KeyError` and `TypeError` as method-not-found and invalid params

### DIFF
--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -37,7 +37,7 @@ async def call(method: Method, *args: Any, **kwargs: Any) -> Any:
 async def safe_call(request: Request, methods: Methods, *, debug: bool) -> Response:
     with handle_exceptions(request, debug) as handler:
         result = await call(
-            methods.items[request.method], *request.args, **request.kwargs
+            methods.lookup(request.method), *request.args, **request.kwargs
         )
         handler.response = SuccessResponse(result=result, id=request.id)
     return handler.response

--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -36,6 +36,7 @@ from .response import (
 )
 from .errors import (
     MethodNotFoundError,
+    InvalidArgumentsError,
     ApiError,
 )
 
@@ -131,9 +132,9 @@ def handle_exceptions(request: Request, debug: bool) -> Generator:
         handler.response = MethodNotFoundResponse(
             id=request.id, data=request.method, debug=debug
         )
-    except (TypeError, AssertionError) as exc:
-        # Invalid Params - TypeError is raised by jsonschema, AssertionError raised
-        # inside the methods.
+    except (InvalidArgumentsError, TypeError, AssertionError) as exc:
+        # Invalid Params - InvalidArgumentsError is raised by validate_args,
+        # AssertionError raised inside the methods.
         handler.response = InvalidParamsResponse(
             id=request.id, data=str(exc), debug=debug
         )

--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -35,6 +35,7 @@ from .response import (
     SuccessResponse,
 )
 from .errors import (
+    MethodNotFoundError,
     ApiError,
 )
 
@@ -126,7 +127,7 @@ def handle_exceptions(request: Request, debug: bool) -> Generator:
     handler = SimpleNamespace(response=None)
     try:
         yield handler
-    except KeyError:
+    except (MethodNotFoundError, KeyError):
         handler.response = MethodNotFoundResponse(
             id=request.id, data=request.method, debug=debug
         )
@@ -163,7 +164,7 @@ def safe_call(request: Request, methods: Methods, *, debug: bool) -> Response:
         A Response object.
     """
     with handle_exceptions(request, debug) as handler:
-        result = call(methods.items[request.method], *request.args, **request.kwargs)
+        result = call(methods.lookup(request.method), *request.args, **request.kwargs)
         handler.response = SuccessResponse(result=result, id=request.id)
     return handler.response
 

--- a/jsonrpcserver/errors.py
+++ b/jsonrpcserver/errors.py
@@ -7,6 +7,10 @@ class MethodNotFoundError(KeyError):
     """ Method lookup failed """
     pass
 
+class InvalidArgumentsError(TypeError):
+    """ Method arguments invalid """
+    pass
+
 class ApiError(RuntimeError):
     """ A method responds with a custom error """
 

--- a/jsonrpcserver/errors.py
+++ b/jsonrpcserver/errors.py
@@ -3,6 +3,10 @@ from typing import Any
 
 from .response import UNSPECIFIED
 
+class MethodNotFoundError(KeyError):
+    """ Method lookup failed """
+    pass
+
 class ApiError(RuntimeError):
     """ A method responds with a custom error """
 

--- a/jsonrpcserver/methods.py
+++ b/jsonrpcserver/methods.py
@@ -10,6 +10,8 @@ from typing import Any, Callable, Optional
 
 from inspect import signature
 
+from .errors import MethodNotFoundError
+
 Method = Callable[..., Any]
 
 
@@ -71,6 +73,24 @@ class Methods:
         if len(args):
             return args[0]  # for the decorator to work
         return None
+
+    def lookup(self, method_name) -> Method:
+        """
+        Lookup a method
+
+        Args:
+            method_name: Method name to look up
+
+        Returns:
+            callable method
+
+        Raises:
+            MethodNotFoundError if method_name is not found
+        """
+        method = self.items.get(method_name)
+        if not method:
+            raise MethodNotFoundError(method_name)
+        return method
 
 
 # A default Methods object which can be used, or user can create their own.

--- a/jsonrpcserver/methods.py
+++ b/jsonrpcserver/methods.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Optional
 
 from inspect import signature
 
-from .errors import MethodNotFoundError
+from .errors import MethodNotFoundError, InvalidArgumentsError
 
 Method = Callable[..., Any]
 
@@ -27,9 +27,12 @@ def validate_args(func: Method, *args: Any, **kwargs: Any) -> Method:
         kwargs: Keyword arguments.
 
     Raises:
-        TypeError: If the arguments cannot be passed to the function.
+        InvalidArgumentsError: If the arguments cannot be passed to the function.
     """
-    signature(func).bind(*args, **kwargs)
+    try:
+        signature(func).bind(*args, **kwargs)
+    except TypeError as exc:
+        raise InvalidArgumentsError from exc
     return func
 
 

--- a/jsonrpcserver/response.py
+++ b/jsonrpcserver/response.py
@@ -270,7 +270,7 @@ class ExceptionResponse(ErrorResponse):
     ) -> None:
         super().__init__(
             "Server error",
-            code=-32000,
+            code=status.JSONRPC_SERVER_ERROR_CODE,
             data=f"{exc.__class__.__name__}: {str(exc)}",
             http_status=http_status,
             *args,

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -3,6 +3,7 @@ from functools import partial
 import pytest
 
 from jsonrpcserver.methods import Methods, add, validate_args
+from jsonrpcserver.errors import MethodNotFoundError
 
 
 def test_validate_no_arguments():
@@ -163,3 +164,18 @@ def test_get():
     methods = Methods(cat, dog)
     assert methods.items["cat"] == cat
     assert methods.items["dog"] == dog
+
+def test_lookup():
+    def foo():
+        pass
+
+    methods = Methods()
+    methods.items["foo"] = foo
+
+    assert methods.lookup("foo") is foo
+
+def test_lookup_failure():
+    methods = Methods()
+
+    with pytest.raises(MethodNotFoundError):
+        methods.lookup("bar")


### PR DESCRIPTION
This addresses #72 and is targeted for the 5.0 branch.
The first two commits are already included in PR #94 .
A point for discussion is whether to keep AssertionErrors causing an InvalidParamsResponse. While assertions can be used for argument validation they might also simply check internal server invariants which should cause a generic server error.