### PR TITLE
Remove legacy exception handlers

### DIFF
--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -124,11 +124,11 @@ def handle_exceptions(request: Request, debug: bool) -> Generator:
     handler = SimpleNamespace(response=None)
     try:
         yield handler
-    except (MethodNotFoundError, KeyError):
+    except MethodNotFoundError:
         handler.response = MethodNotFoundResponse(
             id=request.id, data=request.method, debug=debug
         )
-    except (InvalidArgumentsError, TypeError, AssertionError) as exc:
+    except (InvalidArgumentsError, AssertionError) as exc:
         # Invalid Params - InvalidArgumentsError is raised by validate_args,
         # AssertionError raised inside the methods.
         handler.response = InvalidParamsResponse(


### PR DESCRIPTION
KeyError and TypeError are very generic and might point to an error in
the method implementation rather than in the client. The new exceptions
MethodNotFoundError and InvalidArgumentsError avoid these issues, so
there is no need to catch the generic ones anymore. This effectively
changes method behavior if methods raise KeyErrors and/or TypeErrors.

As pointed out previously, it is debatable whether to keep catching `AssertionError`s as they can be used to check simple server invariants rather than method arguments, too.