### PR TITLE
Make py.typed visible to mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     name="jsonrpcserver",
+    # Be PEP 561 compliant
+    # https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages
     package_data={"jsonrpcserver": ["request-schema.json", "py.typed"]},
+    zip_safe=False,
     packages=["jsonrpcserver"],
     url="https://github.com/bcb/jsonrpcserver",
     version="4.0.5",


### PR DESCRIPTION
Apparently, if you use setuptools and include a `py.typed` file, you need to add `zip_safe=False` to `setup()` in `setup.py` or else mypy can't find it. Who knew! (https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages)

I'm also opening a PR for [jsonrpcclient](https://github.com/bcb/jsonrpcclient).