### PR TITLE
test response serializability early

### DIFF
--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -40,6 +40,8 @@ async def safe_call(request: Request, methods: Methods, *, debug: bool) -> Respo
             lookup(methods, request.method), *request.args, **request.kwargs
         )
         handler.response = SuccessResponse(result=result, id=request.id)
+        # test serializability
+        assert str(handler.response)
     return handler.response
 
 

--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -159,6 +159,8 @@ def safe_call(request: Request, methods: Methods, *, debug: bool) -> Response:
     with handle_exceptions(request, debug) as handler:
         result = call(lookup(methods, request.method), *request.args, **request.kwargs)
         handler.response = SuccessResponse(result=result, id=request.id)
+        # test serializability
+        assert str(handler.response)
     return handler.response
 
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -108,6 +108,21 @@ def test_safe_call_api_error_minimal():
     assert "data" not in error_dict
 
 
+def test_non_json_encodable_resonse():
+    def method():
+        return b"Hello, World"
+
+    response = safe_call(Request(method="method", id=1), Methods(method), debug=False)
+    # response must be serializable here
+    str(response)
+    assert isinstance(response, ErrorResponse)
+    response_dict = response.deserialized()
+    error_dict = response_dict["error"]
+    assert error_dict["message"] == "Server error"
+    assert error_dict["code"] == -32000
+    assert "data" not in error_dict
+
+
 # call_requests
 
 


### PR DESCRIPTION
If a handler method returns a value that cannot be JSON-encoded, an
internal server error should be generated early, so the client gets an
appropriate response and other requests in the same batch still can
succeed (fixes #119).