### PR TITLE
Ensure py.typed is included in the source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include README.md CHANGELOG.md jsonrpcserver/request-schema.json LICENSE
+include README.md CHANGELOG.md LICENSE
+include jsonrpcserver/py.typed jsonrpcserver/request-schema.json


### PR DESCRIPTION
It's not included by setup.py sdist if not listed in MANIFEST.in.

Same problem for `jsonrpcclient`.