### PR TITLE
Improve docs landing page visual structure

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -22,10 +22,20 @@ $ python server.py
 ```
 
 This example uses the built-in server, but any application can process
-requests with the `dispatch()` method. See [examples in various
-frameworks](examples.html), or read the [guide to usage and
-configuration](api.html).
+requests with the `dispatch()` method.
+
+## Examples
+
+See [examples in various frameworks](examples.html).
+
+## Guide
+
+Read the [guide to usage and configuration](api.html).
+
+## Contribute
 
 Contribute on [Github](https://github.com/bcb/jsonrpcserver).
 
-See also: [jsonrpcclient](https://jsonrpcclient.readthedocs.io/)
+## See Also
+
+[jsonrpcclient](https://jsonrpcclient.readthedocs.io/)


### PR DESCRIPTION
The two most important pieces of information in the docs (links to
examples and guide) were the least visible - at the end of longest
paragraph of text on the page just after shiny code examples.

I've introduced h2 headings for the important links while preserving the
original flow of the document.

This should improve docs navigation slightly.